### PR TITLE
Simplify environments config format by removing redundant instances nesting

### DIFF
--- a/benchkit/cli.py
+++ b/benchkit/cli.py
@@ -903,19 +903,41 @@ def check(
 
     # Display Environment section
     env = cfg.get("env") or {}
+    environments = cfg.get("environments") or {}
     env_table = Table(show_header=False, box=None, padding=(0, 2))
     env_table.add_column("Key", style="bold")
     env_table.add_column("Value")
-    env_table.add_row("Mode", env.get("mode", "local"))
-    if env.get("region"):
-        env_table.add_row("Region", env.get("region"))
-    env_table.add_row(
-        "External DB Access",
-        "Yes" if env.get("allow_external_database_access") else "No",
-    )
-    if env.get("ssh_key_name"):
-        env_table.add_row("SSH Key", env.get("ssh_key_name"))
-    console.print(Panel(env_table, title="Environment", border_style="blue"))
+
+    if environments:
+        # New format: show each named environment
+        for env_name, env_cfg in environments.items():
+            mode = env_cfg.get("mode", "local")
+            instance_type = env_cfg.get("instance_type", "")
+            region = env_cfg.get("region", "")
+            details = []
+            if region:
+                details.append(region)
+            if instance_type:
+                details.append(instance_type)
+            value = mode
+            if details:
+                value += f" ({', '.join(details)})"
+            env_table.add_row(env_name, value)
+        panel_title = "Environments"
+    else:
+        # Legacy format
+        env_table.add_row("Mode", env.get("mode", "local"))
+        if env.get("region"):
+            env_table.add_row("Region", env.get("region"))
+        env_table.add_row(
+            "External DB Access",
+            "Yes" if env.get("allow_external_database_access") else "No",
+        )
+        if env.get("ssh_key_name"):
+            env_table.add_row("SSH Key", env.get("ssh_key_name"))
+        panel_title = "Environment"
+
+    console.print(Panel(env_table, title=panel_title, border_style="blue"))
 
     # Display Systems section
     systems = cfg.get("systems", [])

--- a/benchkit/config.py
+++ b/benchkit/config.py
@@ -134,7 +134,15 @@ class EnvironmentConfig(BaseModel):
 
     mode: str = "local"  # local, aws, gcp, azure
     region: str | None = None
-    instances: dict[str, dict[str, Any]] | None = None  # Multi-system instances config
+
+    # Direct instance config (simplified format - when environment serves one system)
+    instance_type: str | None = None
+    disk: dict[str, Any] | None = None
+    label: str | None = None
+
+    # Legacy format (when multiple systems share one environment)
+    instances: dict[str, dict[str, Any]] | None = None
+
     os_image: str | None = None
     ssh_key_name: str | None = None  # SSH key name for cloud instances
     ssh_private_key_path: str | None = None  # Path to private key file for SSH access

--- a/configs/exa_pe_vs_ch_1g.yaml
+++ b/configs/exa_pe_vs_ch_1g.yaml
@@ -17,12 +17,10 @@ environments:
     mode: "aws"
     region: "eu-west-1"
     allow_external_database_access: true
-    instances:
-      clickhouse:
-        instance_type: "r5d.4xlarge"  # 16 vCPUs, 128GB RAM, 2x300GB NVMe local storage
-        disk:
-          type: "local"
-        label: "ok-bench-ch"
+    instance_type: "r5d.4xlarge"  # 16 vCPUs, 128GB RAM, 2x300GB NVMe local storage
+    disk:
+      type: "local"
+    label: "ok-bench-ch"
     os_image: "ubuntu-22.04"
     ssh_key_name: "ok-work3"
     ssh_private_key_path: "~/.ssh/ok-work3.pem"


### PR DESCRIPTION
When using the `environments` configuration format where each environment serves exactly one system, the `instances.{system_name}` nesting was redundant boilerplate. This PR simplifies the config by allowing direct instance fields on the environment.

**Before:**
```yaml
environments:
  clickhouse_cloud:
    mode: "aws"
    instances:
      clickhouse:                    # Redundant - only clickhouse uses this env
        instance_type: "r5d.4xlarge"
        disk: { type: "local" }
        label: "ok-bench-ch"
```

**After:**
```yaml
environments:
  clickhouse_cloud:
    mode: "aws"
    instance_type: "r5d.4xlarge"
    disk: { type: "local" }
    label: "ok-bench-ch"
```

## Changes

- **`benchkit/config.py`**: Added direct instance fields (`instance_type`, `disk`, `label`) to `EnvironmentConfig` model
- **`benchkit/infra/manager.py`**:
  - Added `_extract_instance_config()` helper to abstract instance config extraction
  - Updated `_prepare_terraform_vars()` to use the helper for both formats
  - Improved error messages: distinguishes between "no cloud environments" and "missing instance config"
- **`benchkit/cli.py`**: Fixed `check` command to display `environments` format (was only showing legacy `env`)
- **`configs/exa_pe_vs_ch_1g.yaml`**: Simplified to use new format

## Backward Compatibility

Both formats are fully supported:
- Legacy `env.instances.{system_name}` format (multiple systems sharing one environment)
- Legacy `environments.{name}.instances.{system_name}` format
- New simplified `environments.{name}.instance_type` format (one system per environment)
